### PR TITLE
Überschrift durch YAML front matter ersetzen

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,6 @@
-# Bibliotheks- & Archivinformatik durch machen verstehen
+---
+title: Bibliotheks- & Archivinformatik durch machen verstehen
+---
 
 Hey, schön das du reinschaust!
 Das ist ein Lernblog über Bibliotheks- und Archivinformatik. Dieses Modul haben wir gerade im Informationswissenschafts-Studium. Gerne stelle ich dir  vor, was ich bei Felix Lohmeier im Unterricht lerne.


### PR DESCRIPTION
Das verwendete Theme minima hat ein etwas eigenwilliges Verhalten. Wenn kein Seitentitel definiert ist, nimmt es die erste Überschrift der Indexseite (index.md oder index.html) als Seitentitel. Und da beides dargestellt wird, entsteht dann eine Dopplung. Eine Lösung ist, den Seitentitel so wie hier vorgeschlagen in den Metadaten (im Format YAML "front matter") festzulegen.
Siehe auch:
* Theme Minima zu Content Injection: https://github.com/jekyll/minima#main-heading-and-content-injection
* Jekyll zu Front Matter: https://jekyllrb.com/docs/front-matter/